### PR TITLE
Fix root route coaching message overflow

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -503,8 +503,8 @@ export default function JournalApp() {
       </div>
 
       {/* Column 2: Center Content (Header + Editor) */}
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <div className="flex-1 flex flex-col max-w-3xl mx-auto w-full px-6">
+      <div className="flex-1 min-h-0 flex flex-col overflow-y-auto">
+        <div className="flex-1 min-h-0 flex flex-col max-w-3xl mx-auto w-full px-6">
           {/* Header */}
           <EntryHeader
             currentEntry={currentEntry}
@@ -524,16 +524,18 @@ export default function JournalApp() {
 
           {/* Coaching Message Card - Show only when current entry has linked coaching message */}
           {(coachingMessageData || loadingCoachingMessage) && (
-            <CoachingMessageCard 
-              pushText={coachingMessageData?.pushNotificationText}
-              fullMessage={coachingMessageData?.messageContent}
-              messageType={coachingMessageData?.messageType}
-              loading={loadingCoachingMessage}
-            />
+            <div className="max-h-[50vh] overflow-y-auto rounded-lg">
+              <CoachingMessageCard 
+                pushText={coachingMessageData?.pushNotificationText}
+                fullMessage={coachingMessageData?.messageContent}
+                messageType={coachingMessageData?.messageType}
+                loading={loadingCoachingMessage}
+              />
+            </div>
           )}
           
           {/* Editor */}
-          <div className="flex-1 min-h-0 relative">
+          <div className="flex-1 min-h-0 relative overflow-hidden">
             {currentEntry ? (
               <div className="absolute inset-0 overflow-y-auto overflow-x-hidden scrollbar-hide">
                 <div className="min-h-full pb-[50vh]">
@@ -561,7 +563,7 @@ export default function JournalApp() {
       </div>
 
       {/* Column 3: Right Sidebar */}
-      <div className="w-80 flex-shrink-0 flex flex-col px-6">
+      <div className="w-80 flex-shrink-0 flex flex-col px-6 overflow-y-auto">
         {/* Align with header height */}
         <div className="h-[76px]"></div>
         

--- a/src/components/CoachingMessageCard.tsx
+++ b/src/components/CoachingMessageCard.tsx
@@ -23,7 +23,7 @@ export default function CoachingMessageCard({
   };
 
   return (
-    <div className="w-full bg-gradient-to-r from-purple-50 to-indigo-50 dark:from-purple-900/20 dark:to-indigo-900/20 rounded-xl border border-purple-200 dark:border-purple-700/50 p-4 shadow-sm hover:shadow-md transition-all duration-200 mb-6">
+    <div className="w-full bg-gradient-to-r from-purple-50 to-indigo-50 dark:from-purple-900/20 dark:to-indigo-900/20 rounded-xl border border-purple-200 dark:border-purple-700/50 p-4 shadow-sm hover:shadow-md transition-all duration-200 mb-6 overflow-hidden">
       <div className="flex flex-col gap-3">
         {/* Header */}
         <div className="flex items-center justify-between">
@@ -81,7 +81,7 @@ export default function CoachingMessageCard({
 
         {/* Full message (expandable) */}
         {expanded && !loading && (
-          <div className="border-t border-purple-200 dark:border-purple-700/50 pt-3 mt-1">
+          <div className="border-t border-purple-200 dark:border-purple-700/50 pt-3 mt-1 max-h-[40vh] overflow-y-auto pr-2">
             <div className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed whitespace-pre-wrap">
               {fullMessage}
             </div>


### PR DESCRIPTION
Fixes inability to scroll coaching messages and main content on the root route when content exceeds viewport.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9744d85-0131-4f78-ad81-d2ae954bb24d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d9744d85-0131-4f78-ad81-d2ae954bb24d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

